### PR TITLE
Rename `trim_data` to `strip_id3`

### DIFF
--- a/examples/frames.rs
+++ b/examples/frames.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut f = File::open(path).unwrap();
     let mut buf = Vec::new();
     f.read_to_end(&mut buf).unwrap();
-    let slice = mp3::trim_data(&buf).unwrap();
+    let slice = mp3::strip_id3(&buf).unwrap();
     let mut frame_reader = FrameReader::new(slice);
     while let Some(v) = frame_reader.next_frame().unwrap() {
         println!("{:?}", v.header());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@ impl From<str::Utf8Error> for Mp3Error {
     }
 }
 
-// Trim ID3 tag from data and find first frame
-pub fn trim_data(data: &[u8]) -> Result<&[u8], Mp3Error> {
+/// Strip ID3 tag from data and find first frame
+pub fn strip_id3(data: &[u8]) -> Result<&[u8], Mp3Error> {
     // Check if it is ID3v2
     match &data[..3] {
         b"ID3" => {


### PR DESCRIPTION
`trim_data` was a bit cryptic, so let's rename it to `strip_id3` which is more meaningful, following the discussion in #8.